### PR TITLE
Improve file format for document cache files

### DIFF
--- a/bin/docserv
+++ b/bin/docserv
@@ -379,15 +379,21 @@ class Deliverable:
         return command
 
     def write_deliverable_cache(self, command, thread_id):
-        root = cElementTree.Element("docset")
+        root = cElementTree.Element("document",
+                lang=self.parent.build_instruction['lang'],
+                productid=self.parent.build_instruction['product'],
+                setid=self.parent.build_instruction['docset'],
+                dc=self.dc_file,
+                cachedate=int(time.time()))
+        cElementTree.SubElement(root, "commit").text = self.parent.deliverables[self.id]['last_build_attempt_commit']
+        cElementTree.SubElement(root, "path", format=self.build_format).text = self.path
+        root_id=""
         if self.root_id is not None:
-            doc = cElementTree.SubElement(root, "document", dc=self.dc_file, rootid=self.root_id, format=self.build_format)
-        else:
-            doc = cElementTree.SubElement(root, "document", dc=self.dc_file, format=self.build_format)
-        cElementTree.SubElement(doc, "commit").text = self.parent.deliverables[self.id]['last_build_attempt_commit']
-        cElementTree.SubElement(doc, "path").text = self.path
+            root_id=self.root_id
+        cElementTree.SubElement(root, "title", rootid=root_id).text = self.title
+
         for subdeliverable in self.subdeliverables:
-            cElementTree.SubElement(doc, "subdeliverable", id=subdeliverable).text = self.subdeliverable_titles[subdeliverable]
+            cElementTree.SubElement(root, "title", id=subdeliverable).text = self.subdeliverable_titles[subdeliverable]
         tree = cElementTree.ElementTree(root)
         tree.write(os.path.join(self.deliverable_cache_dir, "%s.xml" % self.dc_file))
         return command


### PR DESCRIPTION
This one is probably not yet in a mergeable state but I'd actually appreciate if you carried it down the road, @svenseeberg. :/

I tried to (partially) address #31 here and also tried to simplify the format I suggested in #18. I have also added a bunch of information that is relevant to me but that so far was not part of the cache file.
However, I have not tried this (because blank readme winkwinknudgenudge). I am not sure whether any of the XPaths we use for selecting the title is broken.

The following is the file format I was shooting for in this PR:

```
<document productid="sled" setid="15ga" lang="en-us" dc="DC-SLES-all" cachedate="123954857">
    <commit>faabbaaf</commit>
    <path format="pdf">en-us/sles/15ga/book.security/book.security_color_en.pdf</path>
    <title rootid="">SLES Documentation</title>
    <title rootid="book.security">Security Guide</title>
</document>
```

As you can see, subdeliverables now only mean that additional `<title/>` tags are created. 