### PR TITLE
Improve logging call

### DIFF
--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -23,12 +23,14 @@ from email.mime.text import MIMEText
 from docserv.deliverable import Deliverable
 from docserv.repolock import RepoLock
 from docserv.functions import resource_to_filename, mail
-logger = logging.getLogger('docserv')
 
 BIN_DIR = os.getenv('DOCSERV_BIN_DIR', "/usr/bin/")
 CONF_DIR = os.getenv('DOCSERV_CONFIG_DIR', "/etc/docserv/")
 SHARE_DIR = os.getenv('DOCSERV_SHARE_DIR', "/usr/share/docserv/")
 CACHE_DIR = os.getenv('DOCSERV_CACHE_DIR', "/var/cache/docserv/")
+
+logger = logging.getLogger('docserv')
+
 
 class BuildInstructionHandler:
     """
@@ -81,7 +83,7 @@ class BuildInstructionHandler:
         Remove temporary files when build fails or all deliverables
         are finished.
         """
-        logger.debug("Cleaning up %s" % json.dumps(self.build_instruction['id']))
+        logger.debug("Cleaning up %s", json.dumps(self.build_instruction['id']))
 
         commands = {}
         n = 0
@@ -118,12 +120,12 @@ class BuildInstructionHandler:
 
         for i in range(0, n + 1):
             cmd = shlex.split(commands[i]['cmd'])
-            logger.debug("Cleaning up %s, %s" % (self.build_instruction['id'], commands[i]['cmd']))
+            logger.debug("Cleaning up %s, %s", self.build_instruction['id'], commands[i]['cmd'])
             s = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = s.communicate()
             if int(s.returncode) != 0:
-                logger.warning("Clean up failed! Unexpected return value %i for '%s'" % (
-                    s.returncode, commands[i]['cmd']))
+                logger.warning("Clean up failed! Unexpected return value %i for '%s'",
+                               s.returncode, commands[i]['cmd'])
                 self.mail(out, err, commands[i]['cmd'])
         self.cleanup_done = True
 
@@ -182,26 +184,26 @@ Repo/Branch: %s %s
         """
         target = self.build_instruction['target']
         if not self.config['targets'][target]['active'] == "yes":
-            logger.debug("Target %s not active." % target)
+            logger.debug("Target %s not active.", target)
             return False
         self.stitch_tmp_dir = tempfile.mkdtemp(prefix="docserv_stitch_")
-        logger.debug("Stitching XML config directory to %s" % self.stitch_tmp_dir)
+        logger.debug("Stitching XML config directory to %s", self.stitch_tmp_dir)
         cmd = '%s/docserv-stitch --make-positive --valid-languages="%s" %s %s' % (
             BIN_DIR,
             self.config['server']['valid_languages'],
             self.config['targets'][target]['config_dir'],
             self.stitch_tmp_dir)
-        logger.debug("Stitching command: %s" % cmd)
+        logger.debug("Stitching command: %s", cmd)
         cmd = shlex.split(cmd)
         s = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         s.communicate()[0]
         rc = int(s.returncode)
         if rc == 0:
-            logger.debug("Stitching of %s successful" %
+            logger.debug("Stitching of %s successful",
                          self.config['targets'][target]['config_dir'])
         else:
-            logger.warning("Stitching of %s failed!" %
+            logger.warning("Stitching of %s failed!",
                            self.config['targets'][target]['config_dir'])
             self.initialized = False
             return False
@@ -234,7 +236,7 @@ Repo/Branch: %s %s
                 self.build_instruction['product'], self.build_instruction['docset'])
             self.remote_repo = xml_root.find(xpath).text
         except AttributeError:
-            logger.warning("Failed to parse xpath: %s" % xpath)
+            logger.warning("Failed to parse xpath: %s", xpath)
             return False
         self.deliverable_cache_base_dir =  '%s/%s' % (CACHE_DIR, self.config['server']['name'])
         return True
@@ -284,13 +286,13 @@ Repo/Branch: %s %s
             cmd = shlex.split(commands[i]['cmd'])
             if commands[i]['repo_lock'] is not None:
                 self.git_lock.acquire()
-            logger.debug("Thread %i: %s" % (thread_id, commands[i]['cmd']))
+            logger.debug("Thread %i: %s", thread_id, commands[i]['cmd'])
             s = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = s.communicate()
             self.git_lock.release()
             if commands[i]['ret_val'] is not None and not commands[i]['ret_val'] == int(s.returncode):
-                logger.warning("Build failed! Unexpected return value %i for '%s'" % (
-                    s.returncode, commands[i]['cmd']))
+                logger.warning("Build failed! Unexpected return value %i for '%s'",
+                    s.returncode, commands[i]['cmd'])
                 self.mail(commands[i]['cmd'], out.decode('utf-8'), err.decode('utf-8'))
                 self.initialized = False
                 return False
@@ -306,7 +308,7 @@ Repo/Branch: %s %s
         s = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         self.build_instruction['commit'] = s.communicate()[0].decode('utf-8').rstrip()
-        logger.debug("Current commit hash: %s" % self.build_instruction['commit'])
+        logger.debug("Current commit hash: %s", self.build_instruction['commit'])
 
     def validate(self, build_instruction, config):
         """
@@ -329,7 +331,7 @@ Repo/Branch: %s %s
         if not isinstance(build_instruction['target'], str):
             logger.warning("Validation: target is not a string")
             return False
-        logger.debug("Valid build instruction: %s" % build_instruction['id'])
+        logger.debug("Valid build instruction: %s", build_instruction['id'])
         return True
 
     def generate_deliverables(self):

--- a/src/docserv/deliverable.py
+++ b/src/docserv/deliverable.py
@@ -50,12 +50,12 @@ class Deliverable:
         self.subdeliverables = subdeliverables
         self.id = self.generate_id()
         self.prev_state()
-        logger.debug("Created deliverable %s (%s, %s) for BI %s" % (
-                                                                self.id,
-                                                                self.dc_file,
-                                                                self.build_format,
-                                                                self.parent.build_instruction['id']
-                                                             ))
+        logger.debug("Created deliverable %s (%s, %s) for BI %s",
+                     self.id,
+                     self.dc_file,
+                     self.build_format,
+                     self.parent.build_instruction['id']
+                     )
 
     def prev_state(self):
         """
@@ -95,22 +95,22 @@ class Deliverable:
         Create a dict of commands that build the document.
         """
         if self.parent.build_instruction['commit'] == self.parent.deliverables[self.id]['successful_build_commit']:
-            logger.debug("Deliverable %s (%s, %s) for BI %s already up to date. Skipping daps run." % (
-                                                                self.id,
-                                                                self.dc_file,
-                                                                self.build_format,
-                                                                self.parent.build_instruction['id']
-                                                             ))
+            logger.debug("Deliverable %s (%s, %s) for BI %s already up to date. Skipping daps run.",
+                         self.id,
+                         self.dc_file,
+                         self.build_format,
+                         self.parent.build_instruction['id'],
+                         )
             return self.finish(True)
         with self.parent.deliverables_open_lock:
             self.parent.deliverables[self.id]['last_build_attempt_commit'] = self.parent.build_instruction['commit']
-        logger.info("Building deliverable %s (%s, %s) for BI %s. Commit: %s" % (
-                                                                        self.id,
-                                                                        self.dc_file,
-                                                                        self.build_format,
-                                                                        self.parent.build_instruction['id'],
-                                                                        self.parent.deliverables[self.id]['last_build_attempt_commit']
-                                                                    ))
+        logger.info("Building deliverable %s (%s, %s) for BI %s. Commit: %s",
+                    self.id,
+                    self.dc_file,
+                    self.build_format,
+                    self.parent.build_instruction['id'],
+                    self.parent.deliverables[self.id]['last_build_attempt_commit'],
+                    )
         #
         # The following lines of code define all bash commands that
         # are required to build and publish the deliverable.
@@ -270,10 +270,10 @@ class Deliverable:
 
         if int(s.returncode) != 0:
             self.failed_command = command['cmd']
-            logger.warning("Thread %i: Build failed! Unexpected return value %i for '%s'" % (
-                thread_id, s.returncode, command['cmd']))
-            logger.warning("Thread %i STDOUT: %s" % (thread_id, self.out.decode('utf-8')))
-            logger.warning("Thread %i STDERR: %s" % (thread_id, self.err.decode('utf-8')))
+            logger.warning("Thread %i: Build failed! Unexpected return value %i for '%s'",
+                           thread_id, s.returncode, command['cmd'])
+            logger.warning("Thread %i STDOUT: %s", thread_id, self.out.decode('utf-8'))
+            logger.warning("Thread %i STDERR: %s", thread_id, self.err.decode('utf-8'))
             self.mail()
             return False
         return True
@@ -347,7 +347,7 @@ Language: %s
             if '_bigfile.xml' not in line and line != "":
                 self.d2d_out_dir = line
                 self.path = ("%s/%s" % (self.deliverable_relative_path, line.split('/')[-1])).replace('//', '/')
-        logger.debug("Deliverable build results: %s" % self.d2d_out_dir)
+        logger.debug("Deliverable build results: %s", self.d2d_out_dir)
         command['cmd'] = command['cmd'].replace('__FILELIST__', self.d2d_out_dir)
         return command
 
@@ -371,14 +371,14 @@ Language: %s
         xmlstarlet['ret_val'] = 0
         if self.root_id:
             bigfile = self.root_id
-            logger.debug("Found ROOTID for %s: %s" % ( self.id, self.root_id ))
+            logger.debug("Found ROOTID for %s: %s", self.id, self.root_id)
             bigfile_path = (os.path.join(command['tmp_build_target'], '.tmp', '%s_bigfile.xml' % bigfile))
             xpath = "(//*[@*[local-name(.)='id']='%s']/*[contains(local-name(.),'info')]/*[local-name(.)='title']|//*[@*[local-name(.)='id']='%s']/*[local-name(.)='title'])[1]" % (
                 self.root_id, self.root_id)
             xmlstarlet['cmd'] = "xmlstarlet sel -t -v \"%s\" %s" % (xpath, bigfile_path)
         else:
             bigfile = self.dc_file.replace('DC-', '')
-            logger.debug("No ROOTID found for %s, using DC file name: %s" % ( self.id, self.dc_file ))
+            logger.debug("No ROOTID found for %s, using DC file name: %s", self.id, self.dc_file)
             bigfile_path = (os.path.join(command['tmp_build_target'], '.tmp', '%s_bigfile.xml' % bigfile))
             xpath = "(/*/*[contains(local-name(.),'info')]/*[local-name(.)='title']|/*/*[local-name(.)='title'])[1]"
             xmlstarlet['cmd'] = "xmlstarlet sel -t -v \"%s\" %s" % (xpath, bigfile_path)

--- a/src/docserv/docserv.py
+++ b/src/docserv/docserv.py
@@ -159,7 +159,7 @@ class DocservState:
         move the build instruction to the past_builds dict and remove
         it from the queued build instructions.
         """
-        logger.info("Aborting build instruction %s" % build_instruction_id)
+        logger.info("Aborting build instruction %s", build_instruction_id)
         with self.scheduled_build_instruction_lock:
             self.updating_build_instruction.remove(build_instruction_id)
             build_instruction = self.scheduled_build_instruction.pop(build_instruction_id, None)
@@ -175,7 +175,7 @@ class DocservState:
         After all deliverables are finished, dump a dict of the
         BuildInstructionHandler into the past_builds dict.
         """
-        logger.info("Finished build instruction %s" % build_instruction_id)
+        logger.info("Finished build instruction %s", build_instruction_id)
         with self.bih_dict_lock:
             build_instruction = self.bih_dict.pop(build_instruction_id)
         with self.past_builds_lock:
@@ -252,7 +252,7 @@ class DocservConfig:
             config_file = "docserv"
         else:
             config_file = argv[1]
-        logger.info("Reading %s/%s.ini" % (CONF_DIR, config_file))
+        logger.info("Reading %s/%s.ini", CONF_DIR, config_file)
         config.read("%s/%s.ini" % (CONF_DIR, config_file))
         self.config = {}
         try:
@@ -284,7 +284,7 @@ class DocservConfig:
                 self.config['targets'][config[section]['name']]['default_lang'] =  config[section]['default_lang']
                 self.config['targets'][config[section]['name']]['internal'] =      config[section]['internal']
         except KeyError as error:
-            logger.warning("Invalid configuration file, missing configuration key '%s'. Exiting." % error)
+            logger.warning("Invalid configuration file, missing configuration key '%s'. Exiting.", error)
             sys.exit(1)
 
 
@@ -312,7 +312,7 @@ class Docserv(DocservState, DocservConfig):
             thread_receive.start()
             workers = []
             for i in range(0, min([os.cpu_count(), self.config['server']['max_threads']])):
-                logger.info("Starting build thread %i" % i)
+                logger.info("Starting build thread %i", i)
                 worker = threading.Thread(target=self.worker, args=(i,))
                 worker.start()
                 workers.append(worker)

--- a/src/docserv/functions.py
+++ b/src/docserv/functions.py
@@ -23,6 +23,7 @@ my_env = os.environ
 
 logger = logging.getLogger('docserv')
 
+
 def resource_to_filename(url):
     """
     To create valid directory names, transform URLs like https://github.com/SUSE/doc-sle
@@ -37,7 +38,7 @@ def mail(text, subject, to):
     """
     Send mail via the local sendmail command.
     """
-    logger.debug("Sending mail to %s" % to)
+    logger.debug("Sending mail to %s", to)
     msg = MIMEText( text )
     msg["To"] = to
     msg["Subject"] = subject

--- a/src/docserv/repolock.py
+++ b/src/docserv/repolock.py
@@ -53,8 +53,9 @@ class RepoLock:
     def acquire(self, blocking=True):
         if self.gitLocks[self.resource_name].acquire(blocking):
             self.acquired = True
-            logger.debug("Thread %i: Acquired lock %s." % (self.thread_id,
-                                                           self.resource_name))
+            logger.debug("Thread %i: Acquired lock %s.",
+                         self.thread_id,
+                         self.resource_name)
             return True
         return False
 
@@ -62,5 +63,6 @@ class RepoLock:
         if self.acquired:
             self.gitLocks[self.resource_name].release()
             self.acquired = False
-            logger.debug("Thread %i: Released lock %s." % (self.thread_id,
-                                                           self.resource_name))
+            logger.debug("Thread %i: Released lock %s.",
+                         self.thread_id,
+                         self.resource_name)

--- a/src/docserv/rest.py
+++ b/src/docserv/rest.py
@@ -5,6 +5,7 @@ import logging
 
 logger = logging.getLogger('docserv')
 
+
 class RESTServer(BaseHTTPRequestHandler):
     def _set_headers(self):
         self.send_response(200)
@@ -28,14 +29,14 @@ class RESTServer(BaseHTTPRequestHandler):
         build_jobs = json.loads(post_data)
         for job in build_jobs:
             if self.server.docserv.queue_build_instruction(job):
-                logger.info("Queueing %s" % json.dumps(job))
+                logger.info("Queueing %s", json.dumps(job))
             else:
-                logger.info("Not queueing %s" % json.dumps(job))
+                logger.info("Not queueing %s", json.dumps(job))
         self._set_headers()
 
 class ThreadedRESTServer(ThreadingMixIn, HTTPServer):
     def __init__(self, server_address, RequestHandlerClass, docserv, bind_and_activate=True):
         HTTPServer.__init__(self, server_address,
                             RequestHandlerClass, bind_and_activate)
-        logger.info("Starting HTTP server on %s:%i" % server_address)
+        logger.info("Starting HTTP server on %s:%i", server_address)
         self.docserv = docserv


### PR DESCRIPTION
Don't evaluate the string, delegate it to the logger module. Especially for bigger objects, this makes it a little bit more performant as logging strings are only evaluated when they are needed.

Basically, this:

```python
logger.info("Person: %s" % "Tux")
```

is replaced by this (see the comma):

```python
logger.info("Person: %s", "Tux")
```