### PR TITLE
Add Thread ID to all BIH log messages

### DIFF
--- a/src/docserv/docserv.py
+++ b/src/docserv/docserv.py
@@ -244,7 +244,7 @@ class DocservState:
             if myBIH.initialized == False:
                 self.abort_build_instruction(build_instruction['id'])
                 return
-            myBIH.generate_deliverables()
+            myBIH.generate_deliverables(thread_id)
             self.remove_scheduled_build_instruction(build_instruction['id'])
             with self.bih_dict_lock:
                 self.bih_dict[build_instruction['id']] = myBIH


### PR DESCRIPTION
* This PR adds the thread id to all log messages of the BIH. Most Deliverable log messages already contained the thread id.
* Partially fixes #98 