### PR TITLE
WIP: Improvements for config-validation.rnc

### DIFF
--- a/config/config.d/sample_product.xml
+++ b/config/config.d/sample_product.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <product productid="sample_product" schemaversion="0.9.9">
+<?xml-model href="../../share/schema/config-validation.rnc" type="application/relax-ng-compact-syntax"?>
   <!-- ID can be used for build commands, HTML IDs, etc. -->
   <!-- lifecycle="unpublished"/"beta"/"supported"/"unsupported":
     + "unpublished": Don't build, don't mention on overview page
@@ -9,7 +10,6 @@
     + "unsupported": build, publish with note "not supported anymore,
       please upgrade"
   -->
-
   <name>Sample Product</name>
   <shortname>SP</shortname>
   <maintainers>

--- a/config/config.d/sample_product.xml
+++ b/config/config.d/sample_product.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<product productid="sample_product" schemaversion="0.9.9">
 <?xml-model href="../../share/schema/config-validation.rnc" type="application/relax-ng-compact-syntax"?>
+<product productid="sample_product" schemaversion="0.9.10">
   <!-- ID can be used for build commands, HTML IDs, etc. -->
   <!-- lifecycle="unpublished"/"beta"/"supported"/"unsupported":
     + "unpublished": Don't build, don't mention on overview page
@@ -10,6 +10,7 @@
     + "unsupported": build, publish with note "not supported anymore,
       please upgrade"
   -->
+
   <name>Sample Product</name>
   <shortname>SP</shortname>
   <maintainers>
@@ -47,9 +48,7 @@
 
     <builddocs>
 
-      <git>
-        <remote>https://github.com/SUSE/doc-sle</remote>
-      </git>
+      <git remote="https://github.com/SUSE/doc-sle"/>
 
       <language default="1" lang="en-us">
         <branch>develop</branch>

--- a/config/config.d/sample_product.xml
+++ b/config/config.d/sample_product.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!-- Notes on the XML model:
+  1. The RNC file provides incomplete validation only, use docserv-stitch for
+     proper validation.
+  2. In the installed package, the XML model is at a different path, this
+     only works within the docserv Git repository. -->
 <?xml-model href="../../share/schema/config-validation.rnc" type="application/relax-ng-compact-syntax"?>
+
 <product productid="sample_product" schemaversion="0.9.10">
   <!-- ID can be used for build commands, HTML IDs, etc. -->
   <!-- lifecycle="unpublished"/"beta"/"supported"/"unsupported":

--- a/share/schema/config-validation.rnc
+++ b/share/schema/config-validation.rnc
@@ -8,7 +8,7 @@ start = ds.product
 
 # CONSTANTS
 
-ds.schema.version = "0.9.9"
+ds.schema.version = "0.9.10"
 
 
 # TYPES
@@ -71,6 +71,8 @@ ds.type.id =
     pattern="""[\-_\.\+a-zA-Z0-9]+"""
   }
 
+ds.false.enum = "0" | "false"
+ds.true.enum = "1" | "true"
 
 # TAG/ATTRIBUTE SETS
 
@@ -84,6 +86,7 @@ ds.htmlblock =
   | ds.pre
   | ds.ul
   | ds.ol
+  | ds.dl
   | ds.h1
   | ds.h2
   | ds.h3
@@ -169,14 +172,14 @@ ds.contact =
 ds.defaultdesc =
   element desc {
     attribute lang { ds.type.lang },
-    attribute default { "1" | "true" },
+    attribute default { ds.true.enum },
     ds.htmlblock+
   }
 
 ds.otherdesc =
   element desc {
     attribute lang { ds.type.lang },
-    attribute default { "0" | "false" }?,
+    attribute default { ds.false.enum }?,
     ds.htmlblock*
   }
 
@@ -212,18 +215,14 @@ ds.builddocs =
 
 ds.git =
   element git {
-    ds.remote
-  }
-
-ds.remote =
-  element remote {
-    ds.type.gitremote
+    attribute remote { ds.type.gitremote },
+    empty
   }
 
 ds.defaultlanguage =
   element language {
     attribute lang { ds.type.lang },
-    attribute default { "1" | "true" },
+    attribute default { ds.true.enum },
     ds.branch,
     ds.subdir?,
     ds.deliverable+
@@ -231,7 +230,7 @@ ds.defaultlanguage =
 ds.otherlanguage =
   element language {
     attribute lang { ds.type.lang },
-    attribute default { "0" | "false" }?,
+    attribute default { ds.false.enum }?,
     ds.branch?,
     ds.subdir?,
     ds.untranslated?
@@ -348,6 +347,23 @@ ds.ol =
     ds.li+
   }
 
+ds.dl =
+  element dl {
+    (ds.dt, ds.dd)+
+  }
+
+ds.dt =
+  element dt {
+    ds.htmlattr,
+    ds.htmlblock*
+  }
+
+ds.dd =
+  element dd {
+    ds.htmlattr,
+    ds.htmlblock*
+  }
+
 ds.li =
   element li {
     ds.htmlattr,
@@ -420,6 +436,7 @@ ds.em =
 ds.a =
   element a {
     attribute href { xsd:anyURI },
+    attribute target { "_blank" }?,
     ds.htmlinlinecontent
   }
 

--- a/share/xslt/positive-config.xsl
+++ b/share/xslt/positive-config.xsl
@@ -51,7 +51,7 @@
 
 
   <xsl:template match="deliverable" mode="create-blacklist-param">
-    <xsl:param name="DC" select="dc"/>
+    <xsl:param name="current-dc" select="dc"/>
     <xsl:variable name="add-to-list">
       <xsl:choose>
         <xsl:when test="subdeliverable">
@@ -63,8 +63,8 @@
             </xsl:for-each>
           </xsl:variable>
           <xsl:variable name="original-subdeliverables">
-            <xsl:if test="ancestor::builddocs/language[@default='true' or @default='1']/deliverable[dc = $DC][subdeliverable]">
-              <xsl:for-each select="ancestor::builddocs/language[@default='true' or @default='1']/deliverable[dc = $DC][subdeliverable]/subdeliverable">
+            <xsl:if test="ancestor::builddocs/language[@default='true' or @default='1']/deliverable[dc = $current-dc][subdeliverable]">
+              <xsl:for-each select="ancestor::builddocs/language[@default='true' or @default='1']/deliverable[dc = $current-dc][subdeliverable]/subdeliverable">
                 <xsl:sort select="translate(., ' &#10;', '')" order="descending"/>
                 <xsl:value-of select="translate(., ' &#10;', '')"/>
                 <xsl:text> </xsl:text>
@@ -81,7 +81,7 @@
     </xsl:variable>
 
     <xsl:if test="$add-to-list = 1">
-      <xsl:value-of select="$DC"/>
+      <xsl:value-of select="$current-dc"/>
       <xsl:text> </xsl:text>
     </xsl:if>
   </xsl:template>
@@ -103,9 +103,9 @@
 
   <xsl:template match="subdeliverable" mode="positize">
     <xsl:param name="langcode" select="''"/>
-    <xsl:variable name="DC" select="preceding-sibling::dc[1]"/>
-    <xsl:variable name="SUB" select="."/>
-    <xsl:if test="not(ancestor::docset/builddocs/language[@lang = $langcode]/untranslated/deliverable[dc = $DC and subdeliverable = $SUB])">
+    <xsl:variable name="current-dc" select="preceding-sibling::dc[1]"/>
+    <xsl:variable name="current-subdeliverable" select="."/>
+    <xsl:if test="not(ancestor::docset/builddocs/language[@lang = $langcode]/untranslated/deliverable[dc = $current-dc and subdeliverable = $current-subdeliverable])">
       <xsl:apply-templates select="self::*"/>
     </xsl:if>
   </xsl:template>

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -241,7 +241,7 @@ Repo/Branch: %s %s
                 self.build_instruction['product'], self.build_instruction['docset'], self.build_instruction['lang'])
             self.branch = xml_root.find(xpath).text
 
-            xpath = ".//product[@productid='%s']/docset[@setid='%s']/builddocs/git/remote" % (
+            xpath = ".//product[@productid='%s']/docset[@setid='%s']/builddocs/git/@remote" % (
                 self.build_instruction['product'], self.build_instruction['docset'])
             self.remote_repo = xml_root.find(xpath).text
         except AttributeError:

--- a/src/docserv/deliverable.py
+++ b/src/docserv/deliverable.py
@@ -395,8 +395,9 @@ Language: %s
             logger.debug("Found ROOTID for %s: %s", self.id, self.root_id)
             bigfile_path = (os.path.join(
                 command['tmp_build_target'], '.tmp', '%s_bigfile.xml' % bigfile))
-            xpath = "(//*[@*[local-name(.)='id']='%s']/*[contains(local-name(.),'info')]/*[local-name(.)='title']|//*[@*[local-name(.)='id']='%s']/*[local-name(.)='title'])[1]" % (
-                self.root_id, self.root_id)
+            xpath = ("(//*[@*[local-name(.)='id']='{ID}']/*[contains(local-name(.),'info')]/*[local-name(.)='title']|"
+                     "//*[@*[local-name(.)='id']='{ID}']/*[local-name(.)='title'])[1]"
+                     ).format(ID=self.root_id)
             xmlstarlet['cmd'] = "xmlstarlet sel -t -v \"%s\" %s" % (
                 xpath, bigfile_path)
         else:


### PR DESCRIPTION
This PR fixes #107 and contains the following changes:

* Add `<dl>` as HTML element to the `ds.htmlblock`
* Create separate patterns for "1" | "true" and "0" | "false"
* Enhance `<a>` with "target" attribute
* Add "global" `<git>` element under `<product>` and make `<git>` under `<builddocs>` optional

Questions to @sknorr 

* Should the `target` attribute just be `text` instead of this list with these `_blank` etc. entries?
* Is it ok to change the `<git>` element to optional under `<product>` *and* `<builddocs>`?
  (I guess, we need to tackle the situation that there is no `<git>` element in the validation script)
