### PR TITLE
WIP: Additional validation checks with XSLT

### DIFF
--- a/bin/docserv-stitch
+++ b/bin/docserv-stitch
@@ -10,8 +10,9 @@
 # INPUT_DIR                       # Directory with config files
 # OUTPUT_FILE                     # Output file name (parent directory must exist)
 #
-# XML tool deps: xmlstarlet, jing, xmllint
-
+# XML tool deps: xmlstarlet, jing, xmllint, xsltproc
+#
+# TODO: Move some checks for xmlstarlet into XSLT stylesheet
 
 out() {
   >&2 echo -e "$1"
@@ -45,9 +46,11 @@ java_flags="-Dorg.apache.xerces.xni.parser.XMLParserConfiguration=org.apache.xer
 
 schema_file=$share_dir/schema/config-validation.rnc
 positive_xslt_file=$share_dir/xslt/positive-config.xsl
+checks_dir=$share_dir/xslt/checks
 
 [[ ! -f $schema_file ]] && out "Schema $schema_file does not exist.$(readme_message)"
 [[ ! -f $positive_xslt_file ]] && out "Schema $positive_xslt_file does not exist.$(readme_message)"
+[[ ! -e $checks_dir ]] && out "Directory $checks_dir does not exist.$(readme_message)"
 
 make_positive=0
 valid_languages=""
@@ -174,7 +177,13 @@ for file in *.xml; do
         "$input_dir/$file: Some lang attributes are not supported by your configuration INI. Check for occurrences of the following unsupported lang attribute(s):\n$unrecognized_languages"
   fi
 
-
+  # Iterate over all XSLT stylesheets (starting with "check") and
+  # apply them to the configuration XML file. Check result of xsltproc.
+  # Each XSLT stylesheet prints "0" (=success) or "10" (=failure).
+  for xslt in $checks_dir/check-*.xsl; do
+    result=$(xsltproc $xslt $file)
+    [ 0 -ne $result ] && out "Check failed for $xslt."
+  done
 done
 
 if [[ "$issuelist" ]]; then

--- a/share/xslt/checks/check-git.xsl
+++ b/share/xslt/checks/check-git.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     Check if we have at least one <git> element, either in
+
+       * /product/git, or
+       * /product/docset/builddocs/git
+
+     This is kind of "dummy check" as the RNG schema requires
+     a /product/git element 
+
+  Parameters:
+     None
+       
+   Input:
+     XML instance of config-validation.rnc
+     
+   Output:
+     "0" = success
+     "10" = failure
+  
+   Author:    Thomas Schraitle <toms@opensuse.org>
+   Copyright (C) 2019 SUSE Linux GmbH
+
+-->
+<xsl:stylesheet version="1.0"
+    xmlns:d="http://docbook.org/ns/docbook"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    exclude-result-prefixes="d">
+
+    <xsl:import href="log.xsl"/>
+    <xsl:output method="text"/>
+
+    <xsl:template match="/product">
+        <xsl:call-template name="git.check"/>
+    </xsl:template>
+
+    <d:para>Checks whether at least one Git repository is definied inside a <d:tag>git</d:tag> tag.</d:para>
+    <xsl:template name="git.check">
+        <xsl:variable name="global.git" select="git"/>
+        <xsl:variable name="local.git" select="docset/builddocs/git"/>
+        <xsl:if test="count($global.git | $local.git) = 0">
+            <xsl:call-template name="log.error">
+                <xsl:with-param name="msg">
+                    <xsl:text>The XML file contains no git element, but I've expected one.</xsl:text>
+                </xsl:with-param>
+            </xsl:call-template>
+            <xsl:text>1</xsl:text>
+        </xsl:if>
+        <xsl:text>0</xsl:text>
+    </xsl:template>
+</xsl:stylesheet>

--- a/share/xslt/checks/log.xsl
+++ b/share/xslt/checks/log.xsl
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     Outputs logging messages
+     
+   Parameters:
+     None
+       
+   Input:
+     None
+     
+   Output:
+     Messages with xsl:message, sometimes terminates
+  
+   Author:    Thomas Schraitle <toms@opensuse.org>
+   Copyright (C) 2019 SUSE Linux GmbH
+
+-->
+<xsl:stylesheet  version="1.0"
+    xmlns:d="http://docbook.org/ns/docbook"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    exclude-result-prefixes="d">
+
+    <xsl:template name="log">
+        <xsl:param name="abort">no</xsl:param>
+        <xsl:param name="msg"/>
+        <xsl:variable name="msg.tmp" select="concat(normalize-space($msg), '&#10;')"/>
+        
+        <!-- Hint: The xsl:choose is necessary here as the terminate
+                   attribute doesn't allow to configure it via AVT.
+        -->
+        <xsl:choose>
+            <xsl:when test="$abort = 'no' or $abort = ''">
+                <xsl:message><xsl:value-of select="$msg.tmp"/></xsl:message>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes"><xsl:value-of select="$msg.tmp"/></xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="log.error">
+        <xsl:param name="msg"/>
+        <xsl:call-template name="log">
+            <xsl:with-param name="msg" select="concat('ERROR: ', $msg)"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template name="log.warn">
+        <xsl:param name="msg"/>
+        <xsl:call-template name="log">
+            <xsl:with-param name="msg" select="concat('WARNING: ', $msg)"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template name="log.fatal">
+        <xsl:param name="msg"/>
+        <xsl:call-template name="log">
+            <xsl:with-param name="msg" select="concat('FATAL: ', $msg)"/>
+            <xsl:with-param name="abort">yes</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This PR contains a first WIP attempt for #63 and #91.

Perform additional checks on an instance of `config-validation.rnc`. This is neccessary as not all conditions can be checked against a RNG schema.

## Design Ideas

* Of course, it's not the end. I will add additional checks. It's just a "proof of concept" for the time being. :wink: 
* All stylesheets are saved in the `share/xslt/checks/` directory.
* There are two types of stylesheets in the `share/xslt/checks/` directory:
   * **check stylesheets**: start with `check-`, some arbitrary name, and end with `.xsl`.
     They check for a very specific condition and are called by the `docserv-stitch` command.
   * **admin stylesheets**: they can have any name, but are imported by the check stylesheets.
* Each check stylesheet returns either "0" (= success) or "10" (= failure). No result is interpreted as an error.

