### PR TITLE
Allow dl element in ds.htmlblock

### DIFF
--- a/share/schema/config-validation.rnc
+++ b/share/schema/config-validation.rnc
@@ -84,6 +84,7 @@ ds.htmlblock =
   | ds.pre
   | ds.ul
   | ds.ol
+  | ds.dl
   | ds.h1
   | ds.h2
   | ds.h3
@@ -346,6 +347,21 @@ ds.ul =
 ds.ol =
   element ol {
     ds.li+
+  }
+
+ds.dl =
+  element dl {
+     (ds.dt, ds.dd)+
+  }
+
+ds.dt =
+  element dt {
+     ds.htmlinlinecontent
+  }
+
+ds.dd =
+  element dd {
+     ds.htmlinlinecontent | ds.htmlblock*
   }
 
 ds.li =


### PR DESCRIPTION
For consistency reasons, Stefan and I decided to allow this (there are other list elements available)

This PR contains the following changes:

* Allow `dl` element in `ds.htmlblock` pattern.
* Add `dt` and `dd` definitions.

Question: I wasn't entirely sure what we should allow inside `dt` and `dd`. The `dt` allows only inline HTML content, but `dd` can additionally have block elements. Would that make sense?

