### PR TITLE
WIP Add an API guide at '/' (fixes #145)

### DIFF
--- a/src/docserv/rest.py
+++ b/src/docserv/rest.py
@@ -7,24 +7,31 @@ logger = logging.getLogger('docserv')
 
 
 class RESTServer(BaseHTTPRequestHandler):
-    def _set_headers(self):
+    def _set_headers(self, mime = 'json'):
         self.send_response(200)
-        self.send_header('Content-type', 'application/json')
+        mimetype = 'application/json'
+        if mime == 'html':
+            mimetype = 'text/html'
+        self.send_header('Content-type', mimetype)
         self.end_headers()
 
     def do_GET(self):
-        if self.path == '/' or self.path == '/build_instructions/':
+        if self.path == '/':
+            self._set_headers(mime='html')
+            self.wfile.write(
+                bytes("<html><head><title>DocServ2 Build Server</title></head><body><h1>DocServ2 API</h1><p>GET information:</p><ul><li>Current Queue: /build_instructions/</li><li>Available Documents: /deliverables/</li></ul><p>To build, POST a JSON like [{\"docset\": \"15ga\", \"lang\": \"en-us\", \"product\": \"sles\", \"target\": \"external\"}] without a path</p></body></html>", 'utf-8'))
+        elif self.path == '/build_instructions' or self.path == '/build_instructions/':
             self._set_headers()
             self.wfile.write(
                 bytes(json.dumps(self.server.docserv.dict()), "utf-8"))
-        elif self.path == '/deliverables/':
+        elif self.path == '/deliverables' or self.path == '/deliverables/':
             self._set_headers()
             self.wfile.write(
                 bytes(json.dumps(self.server.docserv.deliverables), "utf-8"))
 
     def do_POST(self):
         content_length = int(self.headers['Content-Length'])
-        # [{"docset": "15ga", "lang": "en-us", "product": "sles", "target": "external"}. ]
+        # [{"docset": "15ga", "lang": "en-us", "product": "sles", "target": "external"}]
         post_data = self.rfile.read(content_length)
         build_jobs = json.loads(post_data)
         for job in build_jobs:


### PR DESCRIPTION
The current version is probably the worst possible implementation but it
works.

It also seems that using ./sendbuildinstruction now causes
"curl: (52) Empty reply from server". So, I guess something broke here.

And I get "Connection was reset" for /build_instructions & /deliverables