### PR TITLE
ds2: Don't skip build when document is supposedly up-to-date (#195)

### DIFF
--- a/src/docserv/deliverable.py
+++ b/src/docserv/deliverable.py
@@ -89,14 +89,6 @@ class Deliverable:
         """
         Create a dict of commands that build the document.
         """
-        if self.parent.build_instruction['commit'] == self.parent.deliverables[self.id]['successful_build_commit']:
-            logger.debug("Deliverable %s (%s, %s) for BI %s already up to date. Skipping daps run.",
-                         self.id,
-                         self.dc_file,
-                         self.build_format,
-                         self.parent.build_instruction['id'],
-                         )
-            return self.finish(True)
         with self.parent.deliverables_open_lock:
             self.parent.deliverables[self.id]['last_build_attempt_commit'] = self.parent.build_instruction['commit']
         logger.info("Building deliverable %s (%s, %s) for BI %s. Commit: %s",


### PR DESCRIPTION
We try to be clever and avoid rebuilds if the documents should be
up-to-date. However, there is a few important conditions that we
don't check for:

* Do we have any old documents that need to be cleaned up? (Since
  86fd3669 we are always cleaning up all documents of the current
  docset)

* Has the container been updated to fix an issue with the output?

* The current system also does not work properly with how the ZIP
  builder is integrated (because we build a perfect directory of
  documents into /tmp and only want to copy that to the builds dir
  if the docset is still supported, otherwise we should only copy the
  ZIP file).

So, for the moment, let's skip that whole cleverness altogether,
admit defeat and REBUILD ALL THE THINGS!