### PR TITLE
Feature/save stitch work

### DIFF
--- a/bin/docserv-stitch
+++ b/bin/docserv-stitch
@@ -7,6 +7,11 @@
 #                                 # (optional)
 # --simplify                      # Simplify user-generated productconfig so the
 #                                 # docserv daemon can use it (optional)
+# --revalidate-only               # If a file named of the same name as the
+#                                 # output file already exists and it contains a
+#                                 # <hashes/> section matching the current MD5
+#                                 # sums of the XML files in the input directory,
+#                                 # do not do a complete validation
 # --spinner                       # Show a spinner while working, if you or your
 #                                 # CI are impatient and eager to kill processes
 # INPUT_DIR                       # Directory with config files
@@ -90,6 +95,7 @@ simplify_stylesheet=$share_dir/simplify-product-config/simplify.xsl
 
 simplify_config=0
 enable_spinner=0
+revalidate=1
 valid_languages=""
 unknown=""
 input_dir=""
@@ -103,6 +109,9 @@ for i in "$@"
       ;;
       --simplify)
         simplify_config=1
+      ;;
+      --revalidate-only)
+        revalidate=1
       ;;
       --spinner)
         enable_spinner=1
@@ -131,12 +140,32 @@ done
 ([[ "$simplify_config" -eq 1 ]] && [[ -z "$output_file" ]]) && \
   out "--simplify can only be used together with an OUTPUT_FILE parameter."
 
+([[ "$revalidate" -eq 1 ]] && [[ -z "$output_file" ]]) && \
+  out "--revalidate-only can only be used together with an OUTPUT_FILE parameter."
+
 cd $input_dir
+
+[[ ! $(ls *.xml 2>/dev/null) ]] && \
+  out "There are no product configuration files."
+
 
 valid_languages_sorted=''
 [[ "$valid_languages" ]] && valid_languages_sorted=$(echo -e "$valid_languages" | tr ' ' '\n' | sort -u)
 
 issuelist=''
+
+
+# Create md5 hashes for all config files. From the md5sum output, we are only
+# keeping the hashes, as the file names of the config files are actually
+# irrelevant.
+hashsums=$(md5sum *.xml | sort | sed -r 's/\s*[^ ]+$//' | tr '\n' '!')
+
+if [[ "$revalidate" == '1' ]]; then
+  if [[ -f $output_file ]]; then
+    comparisonhashsums=$($starlet sel -t -v "(//hashes)[1]" $output_file)
+    [[ "$comparisonhashsums" == "$hashsums" ]] && exit 0
+  fi
+fi
 
 for file in *.xml; do
 
@@ -179,7 +208,8 @@ if [[ "$issuelist" ]]; then
   out "The following issues occurred when validating:$issuelist\n"
 fi
 
-outfile='<?xml version="1.0" encoding="UTF-8"?>\n<docservconfig>\n\n'
+outfile='<?xml version="1.0" encoding="UTF-8"?>\n<docservconfig>\n'
+outfile+="<hashes>${hashsums}</hashes>\n\n"
 
 for file in *.xml; do
   outfile+=$($starlet sel -t -c "/*" $file)

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -406,7 +406,7 @@ Repo/Branch: %s %s
 
     def generate_deliverables(self):
         """
-        Iterate through delvierable elements in configuration and create
+        Iterate through deliverable elements in configuration and create
         instances of the Deliverable class for each.
         """
         if not self.initialized:

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -77,7 +77,7 @@ class BuildInstructionHandler:
         This directory is used within a build instruction.
         Example: /tmp/ds_caasp_2_en-us_12e312d3/en-us/caasp/2
         """
-        prefix = "ds_{}_{}_{}_".format(self.product, self.docset, self.lang)
+        prefix = "docserv_{}_{}_{}_".format(self.product, self.docset, self.lang)
         self.tmp_dir_bi = tempfile.mkdtemp(prefix=prefix)
 
         self.docset_relative_path = os.path.join(self.lang, self.product, self.docset)

--- a/src/docserv/docserv.py
+++ b/src/docserv/docserv.py
@@ -19,7 +19,7 @@ class DocservState:
 
     ###################################################
     #   The following section contains all dicts and  #
-    #   queues that keep track of stuff to be build   #
+    #   queues that keep track of stuff to be built   #
     ###################################################
     #
     # 1. "queue" for build instructions from REST API


### PR DESCRIPTION
Avoid revalidating wherever possible, and validate the config as the first thing when starting docserv.
Also put stitch output on the command line.
(Fixes #193 & #57, and makes #177 largely irrelevant).


The idea here is that we:

1. when starting, we stitch for all configured targets and save the stitched config files into a session-stable paths (currently the path is stable even across sessions, so that's not ideal)
2. we start the server and our workers
3. when we get a BIH, we give stitch the new parameter --revalidate-only which makes it check the MD5 sums of the product config files and compares them to the existing stitched config.