### PR TITLE
Fix #237: Avoid rsyncing .git directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         ('/usr/share/docserv/simplify-product-config/', glob('share/simplify-product-config/*.xsl')),
         ('/usr/share/docserv/build-navigation/', glob('share/build-navigation/*.xsl')),
         ('/usr/share/docserv/build-navigation/web-resources/', glob('share/build-navigation/web-resources/*')),
+        ('/usr/share/docserv/rsync/', glob('share/rsync/*')),
         ('/usr/lib/systemd/system/', ['systemd/docserv@.service']),
     ],
     author="SUSE Documentation Team",

--- a/share/rsync/rsync_excludes.txt
+++ b/share/rsync/rsync_excludes.txt
@@ -1,0 +1,10 @@
+.git/
+.svn/
+.hg/
+.bzr/
+*~
+*.old
+*.bak
+*.BAK
+*.orig
+*.rej

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -167,7 +167,11 @@ class BuildInstructionHandler:
             target_path = self.config['targets'][self.build_instruction['target']]['target_path']
             n += 1
             commands[n] = {}
-            commands[n]['cmd'] = "rsync --delete-after -lr %s/ %s" % (backup_path, target_path)
+            commands[n]['cmd'] = "rsync --exclude-from '%s' --delete-after -lr %s/ %s" % (
+                os.path.join(SHARE_DIR, 'rsync', 'rsync_excludes.txt'),
+                backup_path,
+                target_path,
+            )
 
             # remove temp directory for navigation page
             n += 1


### PR DESCRIPTION
This PR fixes #239 
Add additional `--cvs-exclude` option to `rsync`