### PR TITLE
bih: Cancel BIs with non-existing languages early on (#262)

### DIFF
--- a/bin/docserv-build-navigation
+++ b/bin/docserv-build-navigation
@@ -176,9 +176,14 @@ for file in "$stitched_config"; do
   [[ ! -f "$file" ]] && out "File $file does not exist."
 done
 
-for dir in "$cache_dir" "$template_dir" "$output_dir"; do
+for dir in "$template_dir" "$output_dir"; do
   [[ ! -d "$dir" ]] && out "Directory $dir does not exist."
 done
+
+# If this is the first build on a new instance and the first product built does
+# not have a `<builddocs/>` section, we need to create the cache dir here.
+# In essentially any other case, the cache dir should already exist.
+[[ ! -d "$cache_dir" ]] && mkdir -p "$cache_dir"
 
 # FIXME: This kind of validation is interesting for CI too, but nestled in here,
 # it's not very accessible to that sort of tooling. It would also be good to

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -388,6 +388,16 @@ These are the details:
             self.initialized = False
             return False
 
+        valid_languages_split = self.config['server']['valid_languages'].split(' ')
+        if not self.lang in valid_languages_split:
+            logger.warning( "Language %s is not valid. "
+                            "This configuration allows the following language codes: %s. "
+                            "Cancelling build instruction." %
+                            (self.lang,
+                             self.config['server']['valid_languages']))
+            self.initialized = False
+            return False
+
         try:
             xpath = "//product[@productid='%s']/maintainers/contact" % (
                 self.product)

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -288,6 +288,11 @@ class BuildInstructionHandler:
         return self.build_instruction
 
     def mail(self, command, out, err):
+        if not hasattr(self, 'remote_repo'):
+            self.remote_repo = "(none)"
+        if not hasattr(self, 'branch'):
+            self.branch = "(none)"
+
         msg = """Cheerio!
 
 Docserv² failed to execute a command during the following build instruction:


### PR DESCRIPTION
This is untested currently. But it's a fairly small change.

----

@tomschr To get a full fix, I'd love to have a look at the error message that you originally got in the context of failing to build `sles/15-SP3/en`. Could you check if you still have this txt file that was indicated in the output you put into pastebin? `~/repos/GL/susedoc/docserv-config/0cache/docserv-message-2021-07-06T11:33:36+02:00-90pifueu.txt`