### PR TITLE
build-nav: Rebuild dependent pages

### DIFF
--- a/bin/docserv-build-navigation
+++ b/bin/docserv-build-navigation
@@ -64,9 +64,17 @@ starlet='xmlstarlet'
 fragment_l10n_schema=$share_dir/build-navigation/fragment-l10n-schema.rnc
 fragment_stylesheet=$share_dir/build-navigation/generate-localized-fragments.xsl
 
+all_stylesheet=$share_dir/build-navigation/list-all-products.xsl
+related_stylesheet=$share_dir/build-navigation/list-related-products.xsl
+
 stylesheet=$share_dir/build-navigation/build-navigation-json.xsl
 docserv_js=$share_dir/build-navigation/web-resources/docservui.js
-[[ ! -f $stylesheet ]] && out "Stylesheet $stylesheet does not exist.$(readme_message)"
+
+for dependency in $fragment_l10n_schema $fragment_stylesheet \
+  $all_stylesheet $related_stylesheet $stylesheet \
+  $docserv_js; do
+  [[ ! -f "$dependency" ]] && out "File $dependency does not exist.$(readme_message)"
+done
 
 stitched_config=
 
@@ -220,7 +228,13 @@ if [[ "$enable_ssi_fragments" -eq 1 ]]; then
   done
 fi
 
-allproducts=$($xsltproc $share_dir/build-navigation/list-all-products.xsl "$stitched_config")
+allproducts=$($xsltproc "$all_stylesheet" "$stitched_config")
+relatedproducts=$($xsltproc \
+  --stringparam product "$relevant_product" \
+  --stringparam docset "$relevant_docset" \
+  --stringparam internal-mode "$internal_mode" \
+  "$related_stylesheet" "$stitched_config" | \
+  sort -u)
 
 if [[ ! $(echo -e "$allproducts" | grep -oP "^${relevant_product}/${relevant_docset}\$") ]]; then
   out "Either product $relevant_product or docset $relevant_docset does not exist."
@@ -307,17 +321,24 @@ done
 stitched_cache+='\n</docservcache>\n'
 echo -e "$stitched_cache" > $cache_file
 
-xsltproc \
-  --stringparam "output_root" "$output_dir/$data_path/" \
-  --stringparam "cache_file" "$cache_file" \
-  --stringparam "internal_mode" "$internal_mode" \
-  --stringparam "ui_languages" "$ui_languages" \
-  --stringparam "site_sections" "$site_sections_deduped" \
-  --stringparam "default_site_section" "$default_site_section" \
-  --stringparam "product" "$relevant_product" \
-  --stringparam "docset" "$relevant_docset" \
-  "$stylesheet" \
-  "$stitched_config"
+for product_docset in "${relevant_product}/${relevant_docset}" $relatedproducts; do
+
+  this_product=$(echo "$product_docset" | cut -f1 -d'/')
+  this_docset=$(echo "$product_docset" | cut -f2 -d'/')
+
+  xsltproc \
+    --stringparam "output_root" "$output_dir/$data_path/" \
+    --stringparam "cache_file" "$cache_file" \
+    --stringparam "internal_mode" "$internal_mode" \
+    --stringparam "ui_languages" "$ui_languages" \
+    --stringparam "site_sections" "$site_sections_deduped" \
+    --stringparam "default_site_section" "$default_site_section" \
+    --stringparam "product" "$this_product" \
+    --stringparam "docset" "$this_docset" \
+    "$stylesheet" \
+    "$stitched_config"
+
+done
 
 # Clean up stray ',' characters that are extremely hard to avoid when
 # generating JSON via XSLT.
@@ -375,21 +396,24 @@ for lang in $ui_languages; do
 
   done
 
-  product="$relevant_product"
-  docset="$relevant_docset"
+  for product_docset in "${relevant_product}/${relevant_docset}" $relatedproducts; do
 
-  mkdir -p $output_dir/$lang/$product/$docset
+    this_product=$(echo "$product_docset" | cut -f1 -d'/')
+    this_docset=$(echo "$product_docset" | cut -f2 -d'/')
 
-  cat "$template_product" | sed -r \
-    -e 's%@\{\{#base_path#}}%'"${base_path}"'%g' \
-    -e 's%@\{\{#base_path_res#}}%'"${base_path}${res_path}"'%g' \
-    -e 's%@\{\{#page_role#}}%'"product"'%g' \
-    -e 's%@\{\{#template_extension#}}%'"$ext"'%g' \
-    -e 's%@\{\{#ui_language#}}%'"$lang"'%g' \
-    -e 's%@\{\{#omit_path_component#}}%'"$omit_lang_path"'%g' \
-    -e 's%@\{\{#product#}}%'"$product"'%g' \
-    -e 's%@\{\{#docset#}}%'"$docset"'%g' \
-    > $output_dir/$lang/$product/$docset/index.$ext
+    mkdir -p "$output_dir/$lang/$this_product/$this_docset"
+
+    cat "$template_product" | sed -r \
+      -e 's%@\{\{#base_path#}}%'"${base_path}"'%g' \
+      -e 's%@\{\{#base_path_res#}}%'"${base_path}${res_path}"'%g' \
+      -e 's%@\{\{#page_role#}}%'"product"'%g' \
+      -e 's%@\{\{#template_extension#}}%'"$ext"'%g' \
+      -e 's%@\{\{#ui_language#}}%'"$lang"'%g' \
+      -e 's%@\{\{#omit_path_component#}}%'"$omit_lang_path"'%g' \
+      -e 's%@\{\{#product#}}%'"$this_product"'%g' \
+      -e 's%@\{\{#docset#}}%'"$this_docset"'%g' \
+      > "$output_dir/$lang/$this_product/$this_docset/index.$ext"
+  done
 
 done
 

--- a/docs/adoc/config-product.adoc
+++ b/docs/adoc/config-product.adoc
@@ -148,12 +148,12 @@ URLs and document titles of such documents must be defined manually.
 {ds2} cannot prevent link breakage or similar issues for these documents.
 
 [IMPORTANT]
-.No page dependency management
+.Partial navigation page dependency management only
 ====
-Docset navigational pages can only be rebuilt individually.
+In certain cases, docset navigational pages will not update when an internal reference are removed.
 
 Internal links can become outdated when the original document is reconfigured but the docset containing the internal reference is not specifically rebuilt after the change.
-Make sure to rebuild dependent docsets manually.
+Make sure to rebuild dependent docsets from which links have been removed manually.
 ====
 
 

--- a/share/build-navigation/list-related-products.xsl
+++ b/share/build-navigation/list-related-products.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet
+[
+]>
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:exsl="http://exslt.org/common">
+  <xsl:output method="text"/>
+
+  <xsl:param name="product">
+    <xsl:message terminate="yes">Need a valid $product XSLT parameter to find related docsets.</xsl:message>
+  </xsl:param>
+  <xsl:param name="docset">
+    <xsl:message terminate="yes">Need a valid $docset XSLT parameter to find related docsets.</xsl:message>
+  </xsl:param>
+  <xsl:param name="internal-mode" select="'false'"/>
+
+  <xsl:template match="@*|node()"/>
+
+  <xsl:template match="/">
+    <xsl:if test="not(//product[@productid = $product])">
+      <xsl:message terminate="yes">Product ID from $product XSLT parameter ("<xsl:value-of select="$product"/>") does not exist.</xsl:message>
+    </xsl:if>
+    <xsl:if test="not(//product[@productid = $product]/docset[@setid = $docset])">
+      <xsl:message terminate="yes">
+        <xsl:text>Docset ID from XSLT parameter $docset ("</xsl:text>
+        <xsl:value-of select="$docset"/>
+        <xsl:text>") does not exist within $product ("</xsl:text>
+        <xsl:value-of select="$product"/>
+        <xsl:text>").</xsl:text>
+      </xsl:message>
+    </xsl:if>
+
+    <xsl:choose>
+      <xsl:when test="$internal-mode = 'true'">
+        <xsl:apply-templates select="//docset/internal/ref"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="//docset[not(@lifecycle = 'unpublished')]/internal/ref"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="ref">
+    <xsl:if test="@product = $product and @docset = $docset">
+      <xsl:value-of select="concat(ancestor::product/@productid, '/', ancestor::docset/@setid, '&#10;')"/>
+    </xsl:if>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
~100% untested but I have high hopes~

Tested now, and after two small fixes, it works. However, there are some pretty large logical gaps here:

* The current code works for updating dependent pages that are referenced from the page of the original docset (i.e. the docset we actively intended to rebuild) by means of a \<ref/\>.
* The current code may remove (still-working) refs from dependent pages if the refs (or underlying documents) have been removed from the newest version of the product config. That may or may not be what you want, but that's probably not a huge issue.
* It has a complete blind spot when it comes to removing historical refs that still exist in the rendered page but no longer in the product config, pointing at the original docset. I could imagine remediating that issue by creating another set of cache files, e.g. `[cache dir]/product-dependencies/[product]/[docset].xml`. These cache files would then include data like:

```
     <docset cachedate="[unix time]" productid="my-product" setid="my-set">
       <depends-on productid="another-product-1" setid="another-set-a"/>
       <depends-on productid="another-product-2" setid="another-set-b"/>
     </docset>
```
(Issue #246 features a different idea: keep configuration from the last build of a docset around for later re-use. But that seems like as bad option.)
* The current code does not deal with the question of docsets that have been removed from the configuration entirely -- although at the very least those would be delisted from the homepage, and it is clear that they have to be cleaned up manually. (Although -- I guess we could use the above-demonstrated extra cache file to clean up such docsets, i.e. `not mentioned in the product config` + `has a cache file` = `delete`.)