### PR TITLE
Keep temorary dirs/files for debugging reasons

### DIFF
--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -191,7 +191,7 @@ class BuildInstructionHandler:
             # remove contents of backup path for current build instruction
             n += 1
             commands[n] = {}
-            commands[n]['cmd'] = "rm -rf %s" % (backup_docset_relative_path)
+            commands[n]['cmd'] = "echo rm -rf %s" % (backup_docset_relative_path)
 
             # ideally, we'd copy in one fell swoop, but I guess two separate
             # commands do work too..?
@@ -216,21 +216,21 @@ class BuildInstructionHandler:
             # remove temp directory for navigation page
             n += 1
             commands[n] = {}
-            commands[n]['cmd'] = "rm -rf %s" % tmp_dir_nav
+            commands[n]['cmd'] = "echo rm -rf %s" % tmp_dir_nav
             commands[n]['execute_after_error'] = True
 
         if hasattr(self, 'tmp_bi_path'):
             # remove temp build instruction directory
             n += 1
             commands[n] = {}
-            commands[n]['cmd'] = "rm -rf %s" % self.tmp_dir_bi
+            commands[n]['cmd'] = "echo rm -rf %s" % self.tmp_dir_bi
             commands[n]['execute_after_error'] = True
 
         if hasattr(self, 'local_repo_build_dir'):
             # build target directory
             n += 1
             commands[n] = {}
-            commands[n]['cmd'] = "rm -rf %s" % self.local_repo_build_dir
+            commands[n]['cmd'] = "echo rm -rf %s" % self.local_repo_build_dir
             commands[n]['execute_after_error'] = True
 
         # rsync local backup path with web server target path

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -111,7 +111,9 @@ class BuildInstructionHandler:
             for deliverable in self.deliverables.keys():
                 if self.deliverables[deliverable]['status'] == 'fail':
                     bi_overall_status = 'fail'
-                    logger.debug("Deliverable failed: %s", deliverable)
+                    logger.debug("Deliverable failed: %s => %s",
+                                 deliverable, item
+                                 )
                     break
 
         logger.debug("Cleaning up after %s (%s)", json.dumps(self.build_instruction['id']), bi_overall_status)

--- a/src/docserv/deliverable.py
+++ b/src/docserv/deliverable.py
@@ -252,17 +252,17 @@ class Deliverable:
         # remove daps parameter file
         n += 1
         commands[n] = {}
-        commands[n]['cmd'] = "rm %s" % (daps_params_file[1])
+        commands[n]['cmd'] = "echo rm %s" % (daps_params_file[1])
 
         # remove xslt parameter file
         n += 1
         commands[n] = {}
-        commands[n]['cmd'] = "rm %s" % (xslt_params_file[1])
+        commands[n]['cmd'] = "echo rm %s" % (xslt_params_file[1])
 
         # remove docker output directory
         n += 1
         commands[n] = {}
-        commands[n]['cmd'] = "rm -rf %s" % (tmp_dir_docker)
+        commands[n]['cmd'] = "echo rm -rf %s" % (tmp_dir_docker)
 
         #
         # Now iterate through all commands and execute them
@@ -300,6 +300,8 @@ class Deliverable:
         s = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         self.out, self.err = s.communicate()
+
+        logging.debug("Command executed: %s => %s || %s", cmd, self.out, self.err)
 
         if int(s.returncode) != 0:
             self.failed_command = command['cmd']

--- a/versionbump
+++ b/versionbump
@@ -13,6 +13,10 @@ files=$(sed -r -n 's/^files: *(([-_./a-zA-Z0-9]+ *)+)/\1/ p' $config)
 changes=$(sed -r -n 's/^changesfile: *(([-_./a-zA-Z0-9]+ *)+)/\1/ p' $config)
 tagprefix=$(sed -r -n 's/^tagprefix: *(([-_./a-zA-Z0-9]+ *)+)/\1/ p' $config)
 
+# In case EDITOR isn't set, use vi as default:
+EDITOR=${EDITOR:-vi}
+
+
 if [[ $1 == '' ]]; then
   currentversion=$(sed -r -n 's/^version: *(.+)$/\1/ p' $config)
   echo "Current version number is $currentversion"


### PR DESCRIPTION
This PR contains:

* Use echo before `rm -rf` for temp dirs/files
* Delete temp dirs and directories with systemd's systemd-tmpfiles-clean