### PR TITLE
Add optional <canonical> tag

### DIFF
--- a/bin/docserv-stitch
+++ b/bin/docserv-stitch
@@ -178,7 +178,7 @@ function parsecli()
     local REST=()
     local options=$(getopt -n "$PROG" \
       -o vh \
-      --long version,help,simplify,revalidate-only,product-config-schema:,valid-languages:,valid-site-sections:,checks-dir: \
+      --long version,help,simplify,spinner,revalidate-only,product-config-schema:,valid-languages:,valid-site-sections:,checks-dir: \
       -- "$@")
     [ $? -eq 0 ] || {
         echo "Incorrect option provided"
@@ -362,7 +362,7 @@ if [[ $simplify_config == 1 ]]; then
   xsltproc $simplify_stylesheet "$tmpoutfile" > $output_file
   # TODO: rm "$tmpoutfile" 2>/dev/null || true
 elif [[ "$output_file" ]]; then
-  cp "$outfile" "$output_file"
+  cp "$tmpoutfile" "$output_file"
 fi
 
 # env_parallel --end-session

--- a/share/validate-product-config/product-config-schema.rnc
+++ b/share/validate-product-config/product-config-schema.rnc
@@ -327,6 +327,7 @@ ds.docset =
     ds.sortname?,
     ds.acronym?,
     ds.version,
+    ds.canonical?,
     ds.listingversion?,
     ds.overridedesc?,
     (
@@ -356,6 +357,11 @@ ds.version =
     ## Whether the version number name includes the product name (default: `false`)
     attribute includes-productname { xsd:boolean }?,
     text
+  }
+ds.canonical =
+  ## For canonical links; from previous, obsolete SPs to the latest
+  element canonical {
+    xsd:anyURI
   }
 ds.listingversion =
   ## User-visible version number (or name of second-level category) displayed in homepage listing


### PR DESCRIPTION
Use it inside <docset> like this:

```xml
<docset lifecycle="supported" setid="12-SP4">
   <version>12 SP4</version>
   <canonical>sles/12-SP5</canonical>
   <!-- ... pruned ... -->
</docset>
```