### PR TITLE
Introduce <desc> with <title>

### DIFF
--- a/share/validate-product-config/product-config-schema.rnc
+++ b/share/validate-product-config/product-config-schema.rnc
@@ -257,6 +257,7 @@ ds.desc_default =
     attribute lang { ds.type.lang },
     ## Whether this is the default language (must be true for initial `<desc/>` element)
     attribute default { ds.true.enum },
+    ds.shortdesc?,
     ds.htmlblock+
   }
 
@@ -268,6 +269,15 @@ ds.desc_translation =
     ## Whether this is the default language (must be false for subsequent `<desc/>` elements)
     attribute default { ds.false.enum }?,
     ds.htmlblock*
+  }
+
+ds.shortdesc_text =
+  xsd:string { pattern = "[^\n]{1,70}" }
+
+ds.shortdesc =
+  ## A short description of the product
+  element title {
+    ds.shortdesc_text
   }
 
 ds.category =


### PR DESCRIPTION
The `<title>` tag inside `<desc>` is used for tiles and a restricted currently to 70 characters.

@fsundermeyer We didn't discuss this in our last doc tools meeting, but I'd like to merge it. Any objections from your part?

This is how it looks like:

```xml
<desc default="1" lang="en-us">
   <title>Short description</title>
   <p>... longer description ...</p>
</desc>
```

Likewise for other languages.
