### PR TITLE
For TRD, allow optional partners inside deliverable

### DIFF
--- a/share/validate-product-config/product-config-schema.rnc
+++ b/share/validate-product-config/product-config-schema.rnc
@@ -481,6 +481,13 @@ ds.subdir =
     ds.type.dirname
   }
 
+ds.partners =
+  ## A list of partners (usually for TRDs)
+  element partners {
+    ## An individual partner
+    element partner { text }+
+  }
+
 ds.deliverable =
   ## An individual DAPS-compatible document built on its own (default language)
   element deliverable {
@@ -506,7 +513,8 @@ ds.deliverable =
     ds.subdir?,
     ds.dc,
     ds.format+,
-    ds.param*
+    ds.param*,
+    ds.partners*
   }
 
 ds.deliverable_subdeliverable =


### PR DESCRIPTION
This PR adds the element `<partners>` to `<deliverable>`. It is only useful for the `trd.xml` config file.

You can write now:

```xml
<deliverable titleformat="title product" category="...">
    <subdir>a/b</subdir>
    <dc>DC-...</dc>
    <format html="1" pdf="1" single-html="1"/>
    <partners>
      <partner>Vendor</partner>
    </partners>
</deliverable>
```