### PR TITLE
Create consistent temp directory

### DIFF
--- a/bin/docserv-stitch
+++ b/bin/docserv-stitch
@@ -93,7 +93,8 @@ spin() {
 }
 
 JOBS=25
-tmpoutfile="docserv-stitch-XXXX.xml"
+DATE=$(date +"%Y-%m-%d")
+tmpoutfile="docserv-stitch-${DATE}.xml"
 xmllint='xmllint'
 jing='jing'
 starlet='xmlstarlet'
@@ -250,7 +251,7 @@ function parsecli()
 
 ## --------
 parsecli $0 "$@"
-debug "Args:\n  input_dir=$input_dir,\n  output_file=$output_file"
+debug "Args:\n  input_dir=$input_dir\n  output_file=$output_file"
 
 # Sanity checks
 [[ ! -f $schema_file ]] && out "Schema $schema_file does not exist.$(readme_message)"
@@ -313,8 +314,11 @@ debug "Config validation was fine."
 debug "======================================="
 debug "Checking each config file..."
 
-tmpoutfile=$(mktemp --tmpdir=/tmp $tmpoutfile)
-TMPCONFIGDIR=$(mktemp -d --tmpdir=/tmp docserv-stitch-tmpdir-XXXX)
+# tmpoutfile=$(mktemp --tmpdir=/tmp $tmpoutfile)
+tmpoutfile="/tmp/$tmpoutfile"
+# TMPCONFIGDIR=$(mktemp -d --tmpdir=/tmp docserv-stitch-tmpdir-XXXX)
+TMPCONFIGDIR="/tmp/docserv-stitch-tmpdir-$DATE"
+mkdir /tmp/docserv-stitch-tmpdir-$DATE 2>/dev/null
 
 cat << EOF > "$tmpoutfile"
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/docserv/bih.py
+++ b/src/docserv/bih.py
@@ -208,7 +208,7 @@ class BuildInstructionHandler:
                     commands[n]['cmd'] = "rsync -lr %s/ %s" % (self.tmp_dir_bi, backup_path)
                 else:
                     # recreate directory
-                    commands[n]['cmd'] = "mkdir -p %s" % (backup_docset_relative_path) 
+                    commands[n]['cmd'] = "mkdir -p %s" % (backup_docset_relative_path)
                     # copy zip archive to directory created above
                     n += 1
                     commands[n] = {}
@@ -386,7 +386,8 @@ These are the details:
             )
         logger.debug("Stitching command: %s", cmd)
         cmd = shlex.split(cmd)
-        s = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+        s = subprocess.Popen(cmd,
+                             stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         self.out, self.err = s.communicate()
         rc = int(s.returncode)


### PR DESCRIPTION
The script created an arbitrary directory at `/tmp/docserv-stitch-tempdir-XXX`. It's changed now:

- The arbitrary directory is gone.
- We use `/tmp/docserv-stitch-tempdir-$DATE`
- DATE is of format "YYY-MM-DD"